### PR TITLE
Enable updatecli integration

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,0 +1,26 @@
+---
+name: Updatecli
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run at 1:00 every Sunday Night
+    - cron: '0 1 * * 1'
+
+permissions:
+  contents: "write"
+  pull-requests: "write"
+
+jobs:
+  updatecli:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@v2
+
+      - name: Run Updatecli in apply mode
+        run: |
+          updatecli apply --config updatecli/updatecli.d/ --values updatecli/values.yaml

--- a/updatecli/updatecli.d/terralist.yaml
+++ b/updatecli/updatecli.d/terralist.yaml
@@ -1,0 +1,55 @@
+---
+name: Bump Terralist version
+
+pipelineid: "terralist"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
+    kind: githubrelease
+    name: Get the latest Terralist version
+    spec:
+      owner: terralist
+      repository: terralist
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+
+conditions:
+  IsDockerImagePublished:
+    name: Check Terralist {{ source "latestVersion" }} docker image tag exists in DockerHub
+    kind: dockerimage
+    spec:
+      image: ghcr.io/terralist/terralist
+      architecture: amd64
+
+targets:
+  imageTag:
+    name: Update Docker Image tag for Terralist to {{ source "latestVersion" }} version
+    kind: yaml
+    spec:
+      file: charts/terralist/Chart.yaml
+      key: $.appVersion
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump Terralist AppVersion to {{ source "latestVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - appversion

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,0 +1,8 @@
+github:
+  user: "treeziops"
+  email: "updatecli-bot@treeziops.io"
+  username: "treeziops"
+  token: "GITHUB_TOKEN"
+  branch: "main"
+  owner: "treezio"
+  repository: "helm-chart-terralist"


### PR DESCRIPTION
Integrate updatecli to enable auto-upgrades of the `terralist` application version.

- Create updatecli pipeline manifest
- Create workflow to be scheduled every sunday night looking for new  releases.